### PR TITLE
Support nil

### DIFF
--- a/lib/uk_postcode/parser_chain.rb
+++ b/lib/uk_postcode/parser_chain.rb
@@ -5,8 +5,9 @@ module UKPostcode
     end
 
     def parse(str)
+      postcode = str.to_s
       @parsers.each do |klass|
-        parsed = klass.parse(str)
+        parsed = klass.parse(postcode)
         return parsed if parsed
       end
       nil

--- a/spec/invalid_postcode_spec.rb
+++ b/spec/invalid_postcode_spec.rb
@@ -4,6 +4,9 @@ describe UKPostcode::InvalidPostcode do
   let(:subject) { described_class.new("anything") }
 
   describe ".parse" do
+    it 'can handle nil' do
+      pc = described_class.parse(nil)
+      expect(pc).to be_instance_of(described_class)
     it "parses anything" do
       pc = described_class.parse("Any old junk")
       expect(pc).to be_instance_of(described_class)

--- a/spec/uk_postcode_spec.rb
+++ b/spec/uk_postcode_spec.rb
@@ -14,6 +14,12 @@ describe UKPostcode do
       expect(subject.to_s).to eq("EH8 8DX")
     end
 
+    it "returns invalid instance for nil" do
+      subject = described_class.parse(nil)
+      expect(subject).to be_instance_of(UKPostcode::InvalidPostcode)
+      expect(subject.to_s).to eq("")
+    end
+    
     it "returns invalid instance for a blank postcode" do
       subject = described_class.parse("")
       expect(subject).to be_instance_of(UKPostcode::InvalidPostcode)


### PR DESCRIPTION
e.g. if I pass in the result of a model parameter which hasn't been set:

```ruby
[3] pry(main)> require 'uk_postcode'
=> false
[4] pry(main)> UKPostcode.parse(nil)
NoMethodError: undefined method `strip' for nil:NilClass
from /home/lloyd/.rvm/gems/ruby-2.2.0/gems/uk_postcode-2.1.0/lib/uk_postcode/giro_postcode.rb:21:in `parse'
[5] pry(main)> UKPostcode.parse(nil.to_s)
=> #<UKPostcode::InvalidPostcode:0x0000000455ab50 @input="">
```

Move the `.to_s` into the gem to prevent users needing to do external checks.