### PR TITLE
Avoid returning nil when one of the parts is nil

### DIFF
--- a/lib/uk_postcode/geographic_postcode.rb
+++ b/lib/uk_postcode/geographic_postcode.rb
@@ -65,7 +65,7 @@ module UKPostcode
     # Returns true if the postcode is a valid full postcode (e.g. W1A 1AA)
     #
     def full?
-      area && district && sector && unit && true
+      !(area.nil? || district.nil? || sector.nil? || unit.nil?)
     end
 
     # Any geographic postcode is assumed to be valid


### PR DESCRIPTION
When providing an incomplete `GeographicPostcode` some methods return `nil` instead of `false`, as stated in the documentation.

Example:
```ruby
pc = UKPostcode.parse('E')

pc.full_valid?
#=> nil

pc.full?
# => nil
```

This PR only changes the method `GeographicPostcode#full?` so it returns true or false, as it should.

All tests are still passing.