### PR TITLE
Update example to use errors.add

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ class PostcodeValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     ukpc = UKPostcode.parse(value)
     unless ukpc.full_valid?
-      record.errors[attribute] << "not recognised as a UK postcode"
+      record.errors.add(attribute, "not recognised as a UK postcode")
     end
   end
 end


### PR DESCRIPTION
The example code no longer works in Rails 6.1 - we can no longer modify the hash directly. This code works!

https://code.lulalala.com/2020/0531-1013.html